### PR TITLE
Fixing issue where channels are not being joined correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "clean": "rm -r dist",
     "seed": "node dist/seedscript.js",
-    "start": "node dist/seedscript.js && node dist/swagger.js && node dist/index.js",
+    "start": "node dist/swagger.js && node dist/index.js",
     "dev": "npm run build && npm start",
     "watch": "nodemon --watch src --ext ts --exec \"npm run dev\"",
     "test": "ava"

--- a/src/controllers/group.ts
+++ b/src/controllers/group.ts
@@ -104,7 +104,7 @@ class GroupsController {
     async addUserToChannel(email: string, groupId: string, channelName: string){
         const db = DB.getInstance();
         try {
-            const value = await db.joinChannel(email, groupId+channelName);
+            const value = await db.joinChannel(email, groupId+"#"+channelName);
         } catch (err) {
             console.error(err);
             throw new HttpError(err, 404);

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -545,7 +545,7 @@ class DB {
     const session = this.localDriver.session({ database: "neo4j" });
     let results = [];
     return new Promise(async (resolve, reject) => {
-      console.log(userEmail, channelUuid)
+      console.log("joining channel ", userEmail, channelUuid)
       try {
         const writeQuery = `MATCH (u:User {email: $userEmail})
         MATCH (c:Channel {channelUuid: $channelUuid})


### PR DESCRIPTION
Change: 
- Adding the "#" separator for the group channel uuid. This was missing before, which meant neo4j was not updating the selected voice channel.
- Removing seed script from npm start command. Since we can run the seed script from npm seed, I think it would be safer to exclude this from the start command, as it wipes the whole database.
