### PR TITLE
Adding Get Users in Voice Channels Endpoint

### DIFF
--- a/src/controllers/group.ts
+++ b/src/controllers/group.ts
@@ -65,6 +65,19 @@ const getFriendsWhoAreNotMembers = (req: Request, res: Response, next: NextFunct
         });
 }
 
+const getUsersInVoiceChannel = async (req: Request, res: Response, next: NextFunction) => {
+    const { groupId, channelName } = req.params;
+    
+    const db = DB.getInstance();
+    db.getUsersInVoiceChannel(groupId, channelName)
+        .then((value) => {
+            res.json(value);
+        })
+        .catch((err) => {
+            throw new HttpError(err, 400);
+        });
+}
+
 // Responsible for handling methods to do with sockets
 class GroupsController {
 
@@ -104,7 +117,7 @@ class GroupsController {
     async addUserToChannel(userId: string, groupId: string, channelName: string){
         const db = DB.getInstance();
         try {
-            const value = await db.joinChannel(userId, groupId+"#"+channelName);
+            const value = await db.joinChannel(userId, groupId, channelName);
         } catch (err) {
             console.error(err);
             throw new HttpError(err, 404);
@@ -127,4 +140,4 @@ class GroupsController {
     }
 }
 
-export {createGroup, getGroups, getMembers, getFriendsWhoAreNotMembers, GroupsController}
+export {createGroup, getGroups, getMembers, getFriendsWhoAreNotMembers, getUsersInVoiceChannel, GroupsController}

--- a/src/controllers/group.ts
+++ b/src/controllers/group.ts
@@ -126,6 +126,7 @@ class GroupsController {
 
     // Disconnect user from all channels
     async disconnectUserFromChannels(userId: string) {
+        console.log("Disconnecting from all channels")
         const db = DB.getInstance();
         try {
             const value = await db.leaveAllChannels(userId);

--- a/src/routes/group.ts
+++ b/src/routes/group.ts
@@ -1,6 +1,12 @@
 // @ts-ignore
 import {Router} from "express"
-import {createGroup, getFriendsWhoAreNotMembers, getGroups, getMembers, GroupsController} from '../controllers/group.js'
+import {createGroup, 
+    getFriendsWhoAreNotMembers, 
+    getGroups, 
+    getMembers, 
+    GroupsController,
+    getUsersInVoiceChannel
+} from '../controllers/group.js'
 import StorageService from '../utils/storage-service.js';
 // @ts-ignore
 import {Namespace, Socket} from "socket.io";
@@ -16,6 +22,8 @@ router.post('/createGroup', createGroup);
 router.get('/getMembers/:groupId', getMembers);
 
 router.get('/getFriendsWhoAreNotMembers/:groupId', getFriendsWhoAreNotMembers);
+
+router.get('/getUsersInVoiceChannel/:groupId/:channelName', getUsersInVoiceChannel)
 
 const groupsRouter = (groupsNamespace: Namespace, notificationNamespace: Namespace) => {
 // Define websockets

--- a/src/routes/group.ts
+++ b/src/routes/group.ts
@@ -58,10 +58,10 @@ const groupsRouter = (groupsNamespace: Namespace, notificationNamespace: Namespa
         socket.on("joinCall", ( member, groupObj, channelName ) => {
             // Disconnect from any existing channels, if any.
             groupsController.disconnectUserFromChannels(userId);
-
+            console.log("Joining call", userId, groupObj.groupId, channelName)
             // Add user to new channel
             groupsController.addUserToChannel(userId, groupObj.groupId, channelName)
-                .then(r => console.log(`User ${userId} added to group ${groupObj.groupId}`));
+                .then(r => console.log(`User ${userId} added to channel ${groupObj.groupId}`));
             groupsNamespace.to(groupObj.groupId).emit('joinCallListener', {...member, id: userId}, channelName)
             console.log("after receiveJoinCall emit")
         })


### PR DESCRIPTION
Purpose: to allow the frontend to populate the voice channels with icons of the users that join the chat

Changes:
- Added a new endpoint to get the users who are currently in a voice channel
- Creating a Neo4j query to support this
- Fixing users joining a channel not updating on the database end
- Updating database profile URL fields to the new name

Testing:
Working locally via postman. Able to get the list of users from endpoint using postman when joining a voice channel.